### PR TITLE
Update __init__.py

### DIFF
--- a/solaredge_modbus/__init__.py
+++ b/solaredge_modbus/__init__.py
@@ -184,8 +184,6 @@ class SolarEdge:
             if (parity
                     and parity.upper() in ["N", "E", "O"]):
                 self.parity = parity.upper()
-            else:
-                self.parity = False
 
             if baud:
                 self.baud = baud


### PR DESCRIPTION
remove a few lines to be able NOT to specify parity when initiating, to prevent parity to be set to False, which results in an error later