### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8
+
+RUN pip3 install pyserial
+
+COPY . /app
+WORKDIR /app
+RUN python3 setup.py install
+
+ENTRYPOINT [ "/usr/local/bin/python3", "example.py" ]

--- a/README.md
+++ b/README.md
@@ -379,3 +379,22 @@ There are two points to consider when doing this. You will need to manually pass
 ## Contributing
 
 Contributions are more than welcome.
+
+## Using Docker to install and run solaredge_modbus
+
+You can build a Docker image and run your scripts inside:
+
+```sh
+docker build -t solaredge_modbus .
+```
+
+You can then execute `example.py` as follows:
+```sh
+docker run --rm -it solaredge_modbus <host> <port>
+```
+You can explore the image or just use it to run other scripts by overriding the entrypoint to the docker image and mounting the outside directory over the `/app/` directory:
+```sh
+docker run --rm -it -v $PWD:/app --entrypoint /bin/bash solaredge_modbus
+
+python3 examply.py <host> <port>
+```


### PR DESCRIPTION
Add a simple Dockerfile to build a Docker container that can run the example script and/or be used for running other custom scripts without having to install python and required libraries directly on your system.