### PR TITLE
Due to modbus update: replaced enum Endian.Big with Endian.BIG

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = solaredge_modbus
-version = 0.7.2
+version = 0.8.0
 author = nmakel
 description = SolarEdge Modbus parser library
 long_description = file: README.md
@@ -25,7 +25,7 @@ packages = find:
 include_package_data = True
 python_requires = >= 3.8
 install_requires =
-    pymodbus == 3.4.1
+    pymodbus == 3.5.4
     pyserial-asyncio >= 0.6.0
 
 [options.packages.find]

--- a/src/solaredge_modbus/__init__.py
+++ b/src/solaredge_modbus/__init__.py
@@ -160,7 +160,7 @@ class SolarEdge:
     stopbits = 1
     parity = "N"
     baud = 115200
-    wordorder = Endian.Big
+    wordorder = Endian.BIG
 
     def __init__(
         self, host=False, port=False,
@@ -247,7 +247,7 @@ class SolarEdge:
             if len(result.registers) != length:
                 continue
 
-            return BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.Big, wordorder=self.wordorder)
+            return BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG, wordorder=self.wordorder)
 
         return None
 
@@ -255,7 +255,7 @@ class SolarEdge:
         return self.client.write_registers(address=address, values=value, slave=self.unit)
 
     def _encode_value(self, data, dtype):
-        builder = BinaryPayloadBuilder(byteorder=Endian.Big, wordorder=self.wordorder)
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=self.wordorder)
 
         try:
             if dtype == registerDataType.INT16:
@@ -425,7 +425,7 @@ class Inverter(SolarEdge):
 
     def __init__(self, *args, **kwargs):
         self.model = "Inverter"
-        self.wordorder = Endian.Big
+        self.wordorder = Endian.BIG
 
         super().__init__(*args, **kwargs)
 
@@ -530,7 +530,7 @@ class Meter(SolarEdge):
 
     def __init__(self, offset=False, *args, **kwargs):
         self.model = f"Meter{offset + 1}"
-        self.wordorder = Endian.Big
+        self.wordorder = Endian.BIG
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
The modbus lib was updated and it's enums are now all upper letters