### PR TITLE
handing of specific endian.LITTLE when needed

### DIFF
--- a/src/solaredge_modbus/__init__.py
+++ b/src/solaredge_modbus/__init__.py
@@ -150,8 +150,7 @@ METER_REGISTER_OFFSETS = [
 
 BATTERY_REGISTER_OFFSETS = [
     0x0,
-    0x100,
-    0x300
+    0x100
 ]
 
 
@@ -169,12 +168,13 @@ class SolarEdge:
         timeout=TIMEOUT, retries=RETRIES, unit=UNIT,
         parent=False
     ):
+        self.little_endian_registers = set()
+
         if parent:
             self.client = parent.client
             self.mode = parent.mode
             self.timeout = parent.timeout
             self.retries = parent.retries
-
             if unit:
                 self.unit = unit
             else:
@@ -235,6 +235,9 @@ class SolarEdge:
             return f"<{self.__class__.__module__}.{self.__class__.__name__} object at {hex(id(self))}>"
 
     def _read_holding_registers(self, address, length):
+        # Check if the register needs little endian
+        wordorder = Endian.LITTLE if address in self.little_endian_registers else self.wordorder
+
         for i in range(self.retries):
             if not self.connected():
                 self.connect()
@@ -242,44 +245,46 @@ class SolarEdge:
                 continue
 
             result = self.client.read_holding_registers(address, length, slave=self.unit)
-
             if not isinstance(result, ReadHoldingRegistersResponse):
                 continue
             if len(result.registers) != length:
                 continue
 
-            return BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG, wordorder=self.wordorder)
+            return BinaryPayloadDecoder.fromRegisters(result.registers, byteorder=Endian.BIG, wordorder=wordorder)
 
         return None
 
-    def _write_holding_register(self, address, value):
-        return self.client.write_registers(address=address, values=value, slave=self.unit)
+    def _write_holding_register(self, address, value, dtype):
+        # Determine byte order based on address
+        wordorder = Endian.LITTLE if address in self.little_endian_registers else self.wordorder
 
-    def _encode_value(self, data, dtype):
-        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=self.wordorder)
+        # Use dtype and wordorder to encode the value properly
+        encoded_value = self._encode_value(value, dtype, wordorder)
+        return self.client.write_registers(address=address, values=encoded_value, slave=self.unit)
+
+    def _encode_value(self, data, dtype, wordorder):
+        builder = BinaryPayloadBuilder(byteorder=Endian.BIG, wordorder=wordorder)
 
         try:
             if dtype == registerDataType.INT16:
                 builder.add_16bit_int(data)
-            elif dtype == registerDataType.INT32:
-                builder.add_32bit_int(data)
             elif dtype == registerDataType.UINT16:
                 builder.add_16bit_uint(data)
+            elif (dtype == registerDataType.FLOAT32 or
+                  dtype == registerDataType.SEFLOAT):
+                builder.add_32bit_float(data)
+            elif dtype == registerDataType.INT32:
+                builder.add_32bit_int(data)
             elif dtype == registerDataType.UINT32:
                 builder.add_32bit_uint(data)
             elif dtype == registerDataType.UINT64:
                 builder.add_64bit_uint(data)
-            elif (dtype == registerDataType.FLOAT32 or
-                  dtype == registerDataType.SEFLOAT):
-                builder.add_32bit_float(data)
             elif dtype == registerDataType.STRING:
                 builder.add_string(data)
             else:
                 raise NotImplementedError(dtype)
-
         except NotImplementedError:
             raise
-
         return builder.to_registers()
 
     def _decode_value(self, data, length, dtype, vtype):
@@ -302,7 +307,6 @@ class SolarEdge:
                 decoded = data.decode_string(length * 2).decode(encoding="utf-8", errors="ignore").replace("\x00", "").rstrip()
             else:
                 raise NotImplementedError(dtype)
-
             if decoded == SUNSPEC_NOTIMPLEMENTED[dtype.name]:
                 return vtype(False)
             elif decoded != decoded:
@@ -314,7 +318,6 @@ class SolarEdge:
 
     def _read(self, value):
         address, length, rtype, dtype, vtype, label, fmt, batch = value
-
         try:
             if rtype == registerType.INPUT:
                 return self._decode_value(self._read_input_registers(address, length), length, dtype, vtype)
@@ -376,11 +379,12 @@ class SolarEdge:
         return results
 
     def _write(self, value, data):
+        # Unpack value tuple to extract necessary information
         address, length, rtype, dtype, vtype, label, fmt, batch = value
-
         try:
             if rtype == registerType.HOLDING:
-                return self._write_holding_register(address, self._encode_value(data, dtype))
+                # Pass dtype to _write_holding_register
+                return self._write_holding_register(address, data, dtype)
             else:
                 raise NotImplementedError(rtype)
         except NotImplementedError:
@@ -429,6 +433,22 @@ class Inverter(SolarEdge):
         self.wordorder = Endian.BIG
 
         super().__init__(*args, **kwargs)
+
+        # A dictionary to hold registers that require different wordorder
+        self.little_endian_registers = {
+            0xf700,  # export_control_mode
+            0xf701,  # export_control_limit_mode
+            0xf702,  # export_control_site_limit
+            0xe004,  # storage_control_mode
+            0xe005,  # storage_ac_charge_policy
+            0xe006,  # storage_ac_charge_limit
+            0xe008,  # storage_backup_reserved_setting
+            0xe00a,  # storage_default_mode
+            0xe00B,  # rc_cmd_timeout
+            0xe00d,  # rc_cmd_mode
+            0xe00e,  # rc_charge_limit
+            0xe010   # rc_discharge_limit
+        }
 
         self.registers = {
             # name, address, length, register, type, target type, description, unit, batch
@@ -502,7 +522,18 @@ class Inverter(SolarEdge):
 
             "export_control_mode": (0xf700, 1, registerType.HOLDING, registerDataType.UINT16, int, "Export Control Mode", "", 5),
             "export_control_limit_mode": (0xf701, 1, registerType.HOLDING, registerDataType.UINT16, int, "Export Control Limit Mode", EXPORT_CONTROL_LIMIT_MAP, 5),
-            "export_control_site_limit": (0xf702, 2, registerType.HOLDING, registerDataType.FLOAT32, int, "Export Control Site Limit", "W", 5)
+            "export_control_site_limit": (0xf702, 2, registerType.HOLDING, registerDataType.FLOAT32, int, "Export Control Site Limit", "W", 5),
+
+            "storage_control_mode": (0xe004, 1, registerType.HOLDING, registerDataType.UINT16, int, "Storage Control Mode", "", 6),
+            "storage_ac_charge_policy": (0xe005, 1, registerType.HOLDING, registerDataType.UINT16, int, "Storage AC Charge Policy", "", 6),
+            "storage_ac_charge_limit": (0xe006, 2, registerType.HOLDING, registerDataType.FLOAT32, float, "Storage AC Charge Limit", "", 6),
+            "storage_backup_reserved_setting": (0xe008, 2, registerType.HOLDING, registerDataType.FLOAT32, float, "Storage Backup Reserved Setting", "%", 6),
+            "storage_default_mode": (0xe00a, 1, registerType.HOLDING, registerDataType.UINT16, int, "Storage Charge/Discharge Default Mode", "", 6),
+            "rc_cmd_timeout": (0xe00B, 2, registerType.HOLDING, registerDataType.UINT32, int, "Remote Control Command Timeout", "s", 6),
+            "rc_cmd_mode": (0xe00d, 1, registerType.HOLDING, registerDataType.UINT16, int, "Remote Control Command Mode", "", 6),
+            "rc_charge_limit": (0xe00e, 2, registerType.HOLDING, registerDataType.FLOAT32, float, "Remote Control Command Charge Limit", "W", 6),
+            "rc_discharge_limit": (0xe010, 2, registerType.HOLDING, registerDataType.FLOAT32, float, "Remote Control Command Discharge Limit", "W", 6)
+
         }
 
         self.meter_dids = [
@@ -513,8 +544,8 @@ class Inverter(SolarEdge):
 
         self.battery_dids = [
             (0xe140, 1, registerType.HOLDING, registerDataType.UINT16, int, "", "", 1),
-            (0xe240, 1, registerType.HOLDING, registerDataType.UINT16, int, "", "", 1),
-            (0xe340, 1, registerType.HOLDING, registerDataType.UINT16, int, "", "", 1)
+            (0xe240, 1, registerType.HOLDING, registerDataType.UINT16, int, "", "", 1)
+#            (0xe340, 1, registerType.HOLDING, registerDataType.UINT16, int, "", "", 1)
         ]
 
     def meters(self):
@@ -526,7 +557,6 @@ class Inverter(SolarEdge):
         batteries = [self._read(v) for v in self.battery_dids]
 
         return {f"Battery{idx + 1}": Battery(offset=idx, parent=self) for idx, v in enumerate(batteries) if v != 255}
-
 
 class Meter(SolarEdge):
 
@@ -628,7 +658,6 @@ class Meter(SolarEdge):
             "l3_export_energy_reactive_q4": (0x9d62 + self.offset, 2, registerType.HOLDING, registerDataType.UINT32, int, "L3 Exported Energy (Reactive) Quadrant 4", "VArh", 3),
             "energy_reactive_scale": (0x9d64 + self.offset, 1, registerType.HOLDING, registerDataType.SCALE, int, "Energy (Reactive) Scale Factor", "", 3)
         }
-
 
 class Battery(SolarEdge):
 


### PR DESCRIPTION
- Added `endian.LITTLE` dict for registers that require wordorder to be `endian.LITTLE` now both BIG & LITTLE work at the same time

- additional registers `export_control_mode, export_control_limit_mode, export_control_site_limit, storage_control_mode, storage_ac_charge_policy, storage_ac_charge_limit, storage_backup_reserved_setting, storage_default_mode, rc_cmd_timeout, rc_cmd_mode, rc_charge_limit, rc_discharge_limit`

- Removed third battery support. seems to conflict with battery1 and battery3 always shows as connected (even when there is no third battery)