### PR TITLE
fix compatibility with pymodbus 3.8.x; constrain version to 3.8.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 include_package_data = True
 python_requires = >= 3.8
 install_requires =
-    pymodbus >= 3.5.0
+    pymodbus ~= 3.8.2
     pyserial-asyncio >= 0.6.0
 
 [options.packages.find]

--- a/src/solaredge_modbus/__init__.py
+++ b/src/solaredge_modbus/__init__.py
@@ -6,7 +6,7 @@ from pymodbus.payload import BinaryPayloadBuilder
 from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.client import ModbusTcpClient
 from pymodbus.client import ModbusSerialClient
-from pymodbus.register_read_message import ReadHoldingRegistersResponse
+from pymodbus.pdu.register_message import ReadHoldingRegistersResponse
 
 
 RETRIES = 3
@@ -241,7 +241,7 @@ class SolarEdge:
                 time.sleep(0.1)
                 continue
 
-            result = self.client.read_holding_registers(address, length, slave=self.unit)
+            result = self.client.read_holding_registers(address, count=length, slave=self.unit)
 
             if not isinstance(result, ReadHoldingRegistersResponse):
                 continue


### PR DESCRIPTION
Fixes #102; supersedes #103 as upstream changed the location again. Also fixes a newly introduced issue I think in 3.8.x where `read_holding_registers` now only takes one positional arg.

To prevent this happening again, constrained the pymodbus version in `setup.cfg`.