### PR TITLE
Request compatible versions of dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ packages = find:
 include_package_data = True
 python_requires = >= 3.8
 install_requires =
-    pymodbus >= 3.5.0
-    pyserial-asyncio >= 0.6.0
+    pymodbus ~= 3.5.0
+    pyserial-asyncio ~= 0.6.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
The `pymodbus` requirement in `setup.cfg` was written as `pymodbus>=3.5.0`, which allows `pip` to choose versions that may be marked as incompatible via semantic versioning, eg. 3.6.x, 3.7.x etc.

This change switches both requirements (`pymodbus` and `pyserial-asyncio`) to use `~=` which restricts them to semver-compatible versions, so for `pymodbus` to 3.5.x. This avoids having to do work like #102 just because upstream has made a breaking change.