### PR TITLE
Update of code to work with pymodbus >= 3.10

### DIFF
--- a/example.py
+++ b/example.py
@@ -76,3 +76,7 @@ if __name__ == "__main__":
         print(f"\tDC Current: {(values['current_dc'] * (10 ** values['current_dc_scale'])):.2f}{inverter.registers['current_dc'][6]}")
         print(f"\tDC Voltage: {(values['voltage_dc'] * (10 ** values['voltage_dc_scale'])):.2f}{inverter.registers['voltage_dc'][6]}")
         print(f"\tDC Power: {(values['power_dc'] * (10 ** values['power_dc_scale'])):.2f}{inverter.registers['power_dc'][6]}")
+
+        print(f"\tAdvanced Power Control Enable: {values['advanced_power_control_enable']}") # See comments in __init__.py
+        print(f"\tReactive Power Config: {values['reactive_power_config']}") # See comments in __init__.py
+        print(f"\tReactive Power Response Time: {values['reactive_power_response_time']}") # See comments in __init__.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 include_package_data = True
 python_requires = >= 3.8
 install_requires =
-    pymodbus ~= 3.5.0
+    pymodbus >= 3.10
     pyserial-asyncio ~= 0.6.0
 
 [options.packages.find]

--- a/src/solaredge_modbus/__init__.py
+++ b/src/solaredge_modbus/__init__.py
@@ -408,10 +408,8 @@ class SolarEdge:
         # Determine contiguous range [addr_min, addr_max)
         addr_min = None
         addr_max = None
-        #v_slave = None
-
+    
         for _k, v in values.items():
-            #v_slave = v[0]
             v_addr = v[0]
             v_len = v[1]
 


### PR DESCRIPTION
Hello,

I have revised the code to be able to work with more modern implementations of pymodbus (version 3.10 upwards). I have splitted the work in 3 different commits:
* Adapted the  SolarEdge class for the private basic read/write and encode/decode values: payload helpers removed (BinaryPayloadDecoder/Builder) → use convert_from_registers / convert_to_registers as well as removed the use of the Endian class. Two commits used (cf8fbe5 and small 64736ee forgotten comment removal)
* Added three lines to the example.py script. While adapting the SolarEdge class, I noticed that register 0xf142 was listed as UINT16, while according to the documentation this should be INT32. Also documentation and code are in conflict on registers: 0xf103/0xf105 in code, while listed as 0xf104/0xf106 in documentation. Unclear to me what should be the correct register address, I have kept original code intact, but added comment to these registers. One commit (6446acb)
* Finally I have updated the setup.cfg to reflect that now pymodbus >= 3.10 is required as the code has been adapted for this version and high (at the moment of writing). I have tested the changes using pymodbus version 3.12.0. I did not update the version number from 0.8.0 to any new value. As you are the owner, it is up to you ;-). One commit (27a3382)